### PR TITLE
Implement MediaTrackCleanService for media track management

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,4 +10,4 @@ N/A
 
 ## Checklist
 
-- [] Relevant documentation updates have been made
+- [ ] Relevant documentation updates have been made

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -148,7 +148,11 @@ jobs:
 
       - name: Run component tests
         run: |
-          docker run --name test-runner ${{ vars.COVERAGE_TEST_IMAGE }} python3 -m pytest --cov=workers --cov-report=xml tests/component
+          docker run --name test-runner \
+            -v ${{ github.workspace }}/workers/src:/app/src \
+            -v ${{ github.workspace }}/workers/tests/component:/app/tests/component \
+            ${{ vars.COVERAGE_TEST_IMAGE }} \
+            python3 -m pytest --cov=workers --cov-report=xml tests/component
 
       - name: Extract coverage report
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -133,4 +133,4 @@ CLAUDE*.md
 docs/feature_plans
 dovi_convert.sh
 docker-compose.override.yaml
-workers/tests/component/assets/*.mkv
+workers/tests/assets

--- a/docs/examples/jellyhook.example.json
+++ b/docs/examples/jellyhook.example.json
@@ -68,6 +68,17 @@
             }
           },
           {
+            "name": "media_track_clean",
+            "enabled": true,
+            "priority": 15,
+            "config": {
+              "keep_original": true,
+              "keep_default": true,
+              "keep_audio_langs": ["eng"],
+              "keep_sub_langs": ["eng", "spa"]
+            }
+          },
+          {
             "name": "dovi_conversion",
             "enabled": true,
             "priority": 20,

--- a/workers/Dockerfile.testenv
+++ b/workers/Dockerfile.testenv
@@ -32,6 +32,7 @@ ENV PATH="/root/.local/bin/:$PATH"
 COPY pyproject.toml README.md ./
 COPY src ./src/
 COPY tests/component ./tests/component/
+COPY tests/assets ./tests/assets/
 
 # Install python dependencies
 RUN uv export > requirements.txt && \

--- a/workers/src/workers/services/__init__.py
+++ b/workers/src/workers/services/__init__.py
@@ -1,9 +1,11 @@
 from workers.services.dovi_conversion import DoviConversionService
+from workers.services.media_track_clean import MediaTrackCleanService
 from workers.services.metadata_update import MetadataUpdateService
 from workers.services.service_base import ServiceBase
 
 __all__ = [
     "DoviConversionService",
+    "MediaTrackCleanService",
     "MetadataUpdateService",
     "ServiceBase",
 ]

--- a/workers/src/workers/services/media_track_clean.py
+++ b/workers/src/workers/services/media_track_clean.py
@@ -1,0 +1,268 @@
+import json
+import os
+import pathlib
+import shlex
+import subprocess
+import tempfile
+from typing import Sequence
+
+from workers.logger import logger
+from workers.models.items import MediaStream, MediaTrackCleanConfig
+from workers.movie import Movie
+from workers.services.service_base import ServiceBase
+from workers.utils import run_command
+
+
+class MediaTrackCleanService(ServiceBase):
+    """Service to clean up media tracks based on configured rules."""
+
+    def __init__(
+        self,
+        movie: Movie,
+        keep_original: bool = True,
+        keep_default: bool = True,
+        keep_audio_langs: list[str] = None,
+        keep_sub_langs: list[str] = None,
+    ) -> None:
+        """Initialize the media track clean service.
+
+        Args:
+            movie: The movie to clean up media tracks for.
+            keep_original: Whether to keep original tracks.
+            keep_default: Whether to keep default tracks.
+            keep_audio_langs: List of languages to keep for audio tracks.
+            keep_sub_langs: List of languages to keep for subtitle tracks.
+        """
+        self.movie = movie
+        self.config = MediaTrackCleanConfig(
+            keep_original=keep_original,
+            keep_default=keep_default,
+            keep_audio_langs=keep_audio_langs or [],
+            keep_sub_langs=keep_sub_langs or [],
+        )
+        self.tmp_dir = pathlib.Path(tempfile.mkdtemp(prefix="jellyhook_media_track_clean_"))
+        logger.info(
+            f"Initialized MediaTrackCleanService for {movie.full_title} with config: "
+            f"keep_original={keep_original}, keep_default={keep_default}, "
+            f"keep_audio_langs={keep_audio_langs}, keep_sub_langs={keep_sub_langs}"
+        )
+
+    def exec(self) -> None:
+        """Execute the media track clean service."""
+        if not os.path.exists(self.movie.full_path):
+            raise FileNotFoundError(f"Movie file not found: {self.movie.full_path}")
+
+        # Get media streams info
+        streams = self._get_media_streams()
+        logger.info(f"Found {len(streams)} streams in {self.movie.full_title}")
+
+        # Evaluate which streams to keep
+        streams_to_keep = self._evaluate_streams(streams)
+        logger.info(f"Keeping {len(streams_to_keep)} streams out of {len(streams)}")
+
+        # Skip if all streams should be kept
+        if len(streams_to_keep) == len(streams):
+            logger.info(
+                f"All streams will be kept, skipping processing for {self.movie.full_title}"
+            )
+            return
+
+        # Create output file name
+        output_file = self._create_output_file_path()
+
+        # Generate and execute ffmpeg command to remove unwanted tracks
+        self._process_file(streams_to_keep, output_file)
+
+        # Replace original file with processed file
+        self._replace_original_file(output_file)
+
+    def _get_media_streams(self) -> list[MediaStream]:
+        """Get media streams from the movie file.
+
+        Returns:
+            A list of MediaStream objects.
+        """
+        # Call ffprobe to get stream information
+        cmd_parts = [
+            "ffprobe",
+            "-v",
+            "error",
+            "-show_streams",
+            "-print_format",
+            "json",
+        ]
+
+        # Convert to shell command
+        cmd = " ".join(shlex.quote(str(part)) for part in cmd_parts) + f" {self.movie.escaped_path}"
+
+        # Execute the command using the utility function
+        try:
+            result = run_command(cmd)
+            # Parse the JSON output
+            ffprobe_data = json.loads(result.stdout)
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as e:
+            logger.error(f"Failed to get media streams from {self.movie.full_path}: {e}")
+            raise
+
+        # Convert to MediaStream objects
+        streams = []
+        for stream_data in ffprobe_data.get("streams", []):
+            # Only consider audio and subtitle streams
+            if stream_data.get("codec_type") in ["audio", "subtitle"]:
+                stream = MediaStream.from_ffprobe(stream_data)
+                streams.append(stream)
+            elif stream_data.get("codec_type") == "video":
+                # Add video streams automatically (they'll always be kept)
+                stream = MediaStream.from_ffprobe(stream_data)
+                streams.append(stream)
+
+        return streams
+
+    def _evaluate_streams(self, streams: list[MediaStream]) -> list[MediaStream]:
+        """Evaluate which streams to keep based on configuration.
+
+        Args:
+            streams: List of media streams.
+
+        Returns:
+            List of streams to keep.
+        """
+        streams_to_keep = []
+
+        for stream in streams:
+            # Always keep video streams
+            if stream.codec_type == "video":
+                streams_to_keep.append(stream)
+                continue
+
+            # Apply rules for audio and subtitle streams
+            keep = False
+
+            # Keep original streams if configured
+            if self.config.keep_original and stream.is_original:
+                keep = True
+                logger.debug(f"Keeping stream {stream.index} (original flag is set)")
+
+            # Keep default streams if configured
+            elif self.config.keep_default and stream.is_default:
+                keep = True
+                logger.debug(f"Keeping stream {stream.index} (default flag is set)")
+
+            # Keep audio streams with matching languages
+            elif stream.codec_type == "audio" and stream.language in self.config.keep_audio_langs:
+                keep = True
+                logger.debug(f"Keeping audio stream {stream.index} (language {stream.language})")
+
+            # Keep subtitle streams with matching languages
+            elif stream.codec_type == "subtitle" and stream.language in self.config.keep_sub_langs:
+                keep = True
+                logger.debug(f"Keeping subtitle stream {stream.index} (language {stream.language})")
+
+            if keep:
+                streams_to_keep.append(stream)
+            else:
+                logger.debug(
+                    f"Removing stream {stream.index} (type: {stream.codec_type}, "
+                    f"language: {stream.language})"
+                )
+
+        return streams_to_keep
+
+    def _create_output_file_path(self) -> pathlib.Path:
+        """Create the output file path.
+
+        Returns:
+            Path to the output file.
+        """
+        # Get the original file extension
+        _, extension = os.path.splitext(self.movie.full_path)
+
+        # Create a temporary output file in the temp directory
+        output_file = self.tmp_dir / f"cleaned{extension}"
+        return output_file
+
+    def _process_file(
+        self, streams_to_keep: Sequence[MediaStream], output_file: pathlib.Path
+    ) -> None:
+        """Process the file to keep only selected streams.
+
+        Args:
+            streams_to_keep: List of streams to keep.
+            output_file: Path to the output file.
+        """
+        # Build ffmpeg command parts
+        cmd_parts = ["ffmpeg", "-i", self.movie.escaped_path]
+
+        # Add map options for each stream to keep
+        for stream in streams_to_keep:
+            cmd_parts.extend(["-map", f"0:{stream.index}"])
+
+        # Copy streams without re-encoding
+        cmd_parts.extend(["-c", "copy"])
+
+        # Copy metadata
+        cmd_parts.extend(["-map_metadata", "0"])
+
+        # Add output file
+        escaped_output = shlex.quote(str(output_file))
+        cmd_parts.append(escaped_output)
+
+        # Convert to shell command
+        cmd = " ".join(str(part) for part in cmd_parts)
+
+        logger.info(f"Running ffmpeg command to clean tracks: {cmd}")
+
+        # Execute the command using the utility function
+        try:
+            run_command(cmd, log_err=True)
+            logger.info(f"Successfully created cleaned file at {output_file}")
+        except subprocess.CalledProcessError as e:
+            logger.error(f"Failed to process file {self.movie.full_path}: {e}")
+            logger.error(f"FFmpeg error: {e.stderr}")
+            raise
+
+    def _replace_original_file(self, output_file: pathlib.Path) -> None:
+        """Replace the original file with the processed file.
+
+        Args:
+            output_file: Path to the processed file.
+        """
+        # Get original file path
+        original_file = self.movie.full_path
+
+        # Create a backup file name
+        backup_file = f"{original_file}.bak"
+
+        # Move original file to backup
+        os.rename(original_file, backup_file)
+        logger.info(f"Created backup of original file at {backup_file}")
+
+        # Move new file to original location
+        os.rename(output_file, original_file)
+        logger.info(f"Moved cleaned file to original location: {original_file}")
+
+        # Remove backup file
+        os.unlink(backup_file)
+        logger.info(f"Removed backup file: {backup_file}")
+
+    @classmethod
+    def from_message(cls, message: dict, service_config: dict) -> "ServiceBase":
+        """Called when a message is received from the queue.
+
+        Args:
+            message: The message to be processed.
+            service_config: The configuration for the service.
+
+        Returns:
+            ServiceBase: An instance of the service.
+        """
+        movie_file = cls.file_from_message(message)
+        movie = Movie.from_file(movie_file)
+        kwargs = {
+            "keep_original": service_config.get("keep_original", True),
+            "keep_default": service_config.get("keep_default", True),
+            "keep_audio_langs": service_config.get("keep_audio_langs", []),
+            "keep_sub_langs": service_config.get("keep_sub_langs", []),
+        }
+
+        return cls(movie, **kwargs)

--- a/workers/src/workers/services/orchestrator.py
+++ b/workers/src/workers/services/orchestrator.py
@@ -18,11 +18,13 @@ from workers.services.service_base import ServiceBase
 SERVICE_MODULES = {
     "metadata_update": "workers.services.metadata_update",
     "dovi_conversion": "workers.services.dovi_conversion",
+    "media_track_clean": "workers.services.media_track_clean",
 }
 
 SERVICE_CLASSES = {
     "metadata_update": "MetadataUpdateService",
     "dovi_conversion": "DoviConversionService",
+    "media_track_clean": "MediaTrackCleanService",
 }
 
 

--- a/workers/tests/component/services/test_media_track_clean.py
+++ b/workers/tests/component/services/test_media_track_clean.py
@@ -1,0 +1,66 @@
+import pytest
+
+from workers.services.media_track_clean import MediaTrackCleanService
+
+
+def test_keep_only_english_tracks(
+    multitrack_service_all_eng, track_clean_command_mock, mock_os_operations
+):
+    """Test that only English audio and subtitle tracks are kept when configured."""
+    # Run the service
+    multitrack_service_all_eng.exec()
+
+    # The mock ffprobe result in conftest.py has 4 audio and 4 subtitle tracks (various langs)
+    # Only English audio (index 1) and English subtitle (index 5) should be kept, plus video (index 0)
+    # The ffmpeg command should map only these indices
+    ffmpeg_call = track_clean_command_mock.call_args_list[1]  # 0 is ffprobe, 1 is ffmpeg
+    cmd = ffmpeg_call[0][0]
+    assert "-map 0:0" in cmd  # video
+    assert "-map 0:1" in cmd  # eng audio
+    assert "-map 0:5" in cmd  # eng subtitle
+    # Should not map other audio/subtitle tracks
+    assert "-map 0:2" not in cmd  # spa audio
+    assert "-map 0:3" not in cmd  # deu audio
+    assert "-map 0:4" not in cmd  # jpn audio
+    assert "-map 0:6" not in cmd  # fra subtitle
+    assert "-map 0:7" not in cmd  # deu subtitle
+    assert "-map 0:8" not in cmd  # jpn subtitle
+
+
+def test_keep_multiple_languages(
+    multitrack_service_multi_langs, track_clean_command_mock, mock_os_operations
+):
+    """Test that multiple audio and subtitle languages are kept when configured."""
+    multitrack_service_multi_langs.exec()
+    # Should keep eng, spa, deu audio (indices 1,2,3) and eng, deu subtitles (indices 5,7), plus video (0)
+    ffmpeg_call = track_clean_command_mock.call_args_list[1]
+    cmd = ffmpeg_call[0][0]
+    assert "-map 0:0" in cmd  # video
+    assert "-map 0:1" in cmd  # eng audio
+    assert "-map 0:2" in cmd  # spa audio
+    assert "-map 0:3" in cmd  # deu audio
+    assert "-map 0:5" in cmd  # eng subtitle
+    assert "-map 0:7" in cmd  # deu subtitle
+    # Should not map jpn audio or fra/jpn subtitles
+    assert "-map 0:4" not in cmd  # jpn audio
+    assert "-map 0:6" not in cmd  # fra subtitle
+    assert "-map 0:8" not in cmd  # jpn subtitle
+
+
+def test_skip_processing_if_all_streams_kept(
+    monkeypatch, multitrack_movie, track_clean_command_mock
+):
+    """Test that processing is skipped if all streams are to be kept."""
+    # Configure service to keep all tracks
+    service = MediaTrackCleanService(
+        multitrack_movie,
+        keep_original=True,
+        keep_default=True,
+        keep_audio_langs=["eng", "spa", "deu", "jpn"],
+        keep_sub_langs=["eng", "fra", "deu", "jpn"],
+    )
+    # Patch _process_file and _replace_original_file to ensure they're not called
+    monkeypatch.setattr(service, "_process_file", pytest.fail)
+    monkeypatch.setattr(service, "_replace_original_file", pytest.fail)
+    # Should not raise and should use the track_clean_command_mock for ffprobe
+    service.exec()

--- a/workers/tests/unit/services/test_media_track_clean.py
+++ b/workers/tests/unit/services/test_media_track_clean.py
@@ -1,0 +1,313 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from workers.models.items import MediaStream, MediaTrackCleanConfig
+from workers.services.media_track_clean import MediaTrackCleanService
+
+
+def test_media_stream_from_ffprobe():
+    """Test creating a MediaStream from ffprobe output."""
+    # Sample ffprobe data for a stream
+    stream_data = {
+        "index": 1,
+        "codec_type": "audio",
+        "tags": {"language": "eng"},
+        "disposition": {"default": 1, "original": 0},
+    }
+
+    stream = MediaStream.from_ffprobe(stream_data)
+
+    assert stream.index == 1
+    assert stream.codec_type == "audio"
+    assert stream.language == "eng"
+    assert stream.is_default is True
+    assert stream.is_original is False
+
+
+def test_media_stream_from_ffprobe_no_tags():
+    """Test creating a MediaStream with missing tags."""
+    stream_data = {
+        "index": 1,
+        "codec_type": "audio",
+        "disposition": {"default": 1, "original": 0},
+    }
+
+    stream = MediaStream.from_ffprobe(stream_data)
+
+    assert stream.index == 1
+    assert stream.codec_type == "audio"
+    assert stream.language == "und"  # Default to 'und' when language is missing
+    assert stream.is_default is True
+    assert stream.is_original is False
+
+
+def test_media_stream_from_ffprobe_no_disposition():
+    """Test creating a MediaStream with missing disposition."""
+    stream_data = {"index": 1, "codec_type": "audio", "tags": {"language": "eng"}}
+
+    stream = MediaStream.from_ffprobe(stream_data)
+
+    assert stream.index == 1
+    assert stream.codec_type == "audio"
+    assert stream.language == "eng"
+    assert stream.is_default is False
+    assert stream.is_original is False
+
+
+def test_media_track_clean_config_with_defaults():
+    """Test initialization with default values."""
+    config = MediaTrackCleanConfig()
+
+    assert config.keep_original is True
+    assert config.keep_default is True
+    assert config.keep_audio_langs == []
+    assert config.keep_sub_langs == []
+
+
+def test_media_track_clean_config_with_values():
+    """Test initialization with provided values."""
+    config = MediaTrackCleanConfig(
+        keep_original=False,
+        keep_default=False,
+        keep_audio_langs=["eng"],
+        keep_sub_langs=["eng", "spa"],
+    )
+
+    assert config.keep_original is False
+    assert config.keep_default is False
+    assert config.keep_audio_langs == ["eng"]
+    assert config.keep_sub_langs == ["eng", "spa"]
+
+
+def test_media_track_clean_config_from_dict():
+    """Test creating configuration from a dictionary."""
+    config_dict = {
+        "keep_original": False,
+        "keep_default": True,
+        "keep_audio_langs": ["eng", "jpn"],
+        "keep_sub_langs": ["eng", "spa", "fre"],
+    }
+
+    config = MediaTrackCleanConfig.from_dict(config_dict)
+
+    assert config.keep_original is False
+    assert config.keep_default is True
+    assert config.keep_audio_langs == ["eng", "jpn"]
+    assert config.keep_sub_langs == ["eng", "spa", "fre"]
+
+
+def test_media_track_clean_config_from_dict_defaults():
+    """Test creating configuration from a partial dictionary."""
+    config_dict = {"keep_audio_langs": ["eng"]}
+
+    config = MediaTrackCleanConfig.from_dict(config_dict)
+
+    assert config.keep_original is True  # Default
+    assert config.keep_default is True  # Default
+    assert config.keep_audio_langs == ["eng"]
+    assert config.keep_sub_langs == []  # Default
+
+
+@patch("workers.services.media_track_clean.tempfile.mkdtemp")
+@patch("workers.services.media_track_clean.Movie")
+def test_media_track_clean_service_init(mock_movie, mock_mkdtemp):
+    """Test initializing the service."""
+    mock_movie.full_title = "Test Movie (2023)"
+    mock_mkdtemp.return_value = "/tmp/test_dir"
+
+    service = MediaTrackCleanService(
+        movie=mock_movie,
+        keep_original=True,
+        keep_default=True,
+        keep_audio_langs=["eng"],
+        keep_sub_langs=["eng", "spa"],
+    )
+
+    assert service.movie == mock_movie
+    assert service.config.keep_original is True
+    assert service.config.keep_default is True
+    assert service.config.keep_audio_langs == ["eng"]
+    assert service.config.keep_sub_langs == ["eng", "spa"]
+    assert service.tmp_dir == Path("/tmp/test_dir")
+
+
+@pytest.fixture
+def mock_movie():
+    """Create a mock movie for testing."""
+    mock = MagicMock()
+    mock.full_path = "/fake/path/movie.mkv"
+    mock.full_title = "Test Movie (2023)"
+    return mock
+
+
+@pytest.fixture
+def mock_ffprobe_output():
+    """Create sample ffprobe output for testing."""
+    return {
+        "streams": [
+            {"index": 0, "codec_type": "video", "disposition": {"default": 1, "original": 0}},
+            {
+                "index": 1,
+                "codec_type": "audio",
+                "tags": {"language": "eng"},
+                "disposition": {"default": 1, "original": 0},
+            },
+            {
+                "index": 2,
+                "codec_type": "audio",
+                "tags": {"language": "spa"},
+                "disposition": {"default": 0, "original": 0},
+            },
+            {
+                "index": 3,
+                "codec_type": "subtitle",
+                "tags": {"language": "eng"},
+                "disposition": {"default": 0, "original": 0},
+            },
+        ]
+    }
+
+
+@patch("workers.services.media_track_clean.os.path.exists")
+@patch("workers.services.media_track_clean.run_command")
+@patch("workers.services.media_track_clean.os.rename")
+@patch("workers.services.media_track_clean.os.unlink")
+def test_media_track_clean_service_exec_success(
+    mock_unlink, mock_rename, mock_run_command, mock_exists, mock_movie, mock_ffprobe_output
+):
+    """Test successful execution of the service."""
+    # Setup mocks
+    mock_exists.return_value = True
+
+    # Set up the movie mock with escaped_path
+    mock_movie.escaped_path = "/fake/path/movie.mkv"
+
+    # Mock run_command to return ffprobe output and success for ffmpeg
+    ffprobe_result = MagicMock()
+    ffprobe_result.stdout = json.dumps(mock_ffprobe_output)
+
+    ffmpeg_result = MagicMock()
+    ffmpeg_result.returncode = 0
+
+    mock_run_command.side_effect = [ffprobe_result, ffmpeg_result]
+
+    # Create and configure service
+    service = MediaTrackCleanService(
+        mock_movie,
+        keep_original=True,
+        keep_default=True,
+        keep_audio_langs=["eng"],
+        keep_sub_langs=["eng"],
+    )
+    service.tmp_dir = Path("/tmp/test_dir")
+
+    # Run the service
+    service.exec()
+
+    # Check if ffprobe was called with the right command
+    ffprobe_expected_cmd = "ffprobe -v error -show_streams -print_format json /fake/path/movie.mkv"
+    assert mock_run_command.call_args_list[0][0][0].strip() == ffprobe_expected_cmd.strip()
+
+    # Check if ffmpeg was called
+    ffmpeg_call = mock_run_command.call_args_list[1][0][0]
+    assert "ffmpeg" in ffmpeg_call
+    assert "-i /fake/path/movie.mkv" in ffmpeg_call
+
+    # Verify the map arguments for streams we want to keep
+    assert "-map 0:0" in ffmpeg_call  # Video stream
+    assert "-map 0:1" in ffmpeg_call  # English audio (default)
+    assert "-map 0:3" in ffmpeg_call  # English subtitle
+    assert "-map 0:2" not in ffmpeg_call  # Spanish audio should be removed
+
+    # Verify copy settings and metadata preservation
+    assert "-c copy" in ffmpeg_call
+    assert "-map_metadata 0" in ffmpeg_call
+
+    # Check file operations
+    mock_rename.assert_any_call("/fake/path/movie.mkv", "/fake/path/movie.mkv.bak")
+    # The second rename uses a Path object, so we need to check more carefully
+    assert any(
+        args[0][0] == Path("/tmp/test_dir/cleaned.mkv") and args[0][1] == "/fake/path/movie.mkv"
+        for args in mock_rename.call_args_list
+    )
+    mock_unlink.assert_called_once_with("/fake/path/movie.mkv.bak")
+
+
+@patch("workers.services.media_track_clean.os.path.exists")
+@patch("workers.services.media_track_clean.run_command")
+def test_media_track_clean_service_exec_skip_when_no_changes(
+    mock_run_command, mock_exists, mock_movie
+):
+    """Test that processing is skipped when no streams would be removed."""
+    # Mock ffprobe output - all streams match our criteria
+    ffprobe_output = {
+        "streams": [
+            {"index": 0, "codec_type": "video", "disposition": {"default": 1, "original": 0}},
+            {
+                "index": 1,
+                "codec_type": "audio",
+                "tags": {"language": "eng"},
+                "disposition": {"default": 1, "original": 0},
+            },
+        ]
+    }
+
+    # Setup mocks
+    mock_exists.return_value = True
+    mock_movie.escaped_path = "/fake/path/movie.mkv"
+
+    # Mock run_command to return ffprobe output
+    ffprobe_result = MagicMock()
+    ffprobe_result.stdout = json.dumps(ffprobe_output)
+    mock_run_command.return_value = ffprobe_result
+
+    # Create and configure service
+    service = MediaTrackCleanService(
+        mock_movie,
+        keep_original=True,
+        keep_default=True,
+        keep_audio_langs=["eng"],
+        keep_sub_langs=["eng"],
+    )
+
+    # Run the service
+    service.exec()
+
+    # Check that ffprobe was called but ffmpeg was not
+    assert mock_run_command.call_count == 1
+
+    # Verify the command contained ffprobe
+    ffprobe_call = mock_run_command.call_args[0][0]
+    assert "ffprobe" in ffprobe_call
+
+
+@patch.object(MediaTrackCleanService, "file_from_message")
+@patch("workers.services.media_track_clean.Movie")
+def test_media_track_clean_service_from_message(mock_movie_class, mock_file_from_message):
+    """Test creating a service instance from a message."""
+    mock_file_path = MagicMock()
+    mock_movie = MagicMock()
+
+    # Setup mocks
+    mock_file_from_message.return_value = mock_file_path
+    mock_movie_class.from_file.return_value = mock_movie
+
+    # Create service from message
+    message = {"key": "value"}
+    service_config = {"keep_original": False, "keep_audio_langs": ["eng"]}
+
+    service = MediaTrackCleanService.from_message(message, service_config)
+
+    # Verify mocks were called correctly
+    mock_file_from_message.assert_called_once_with(message)
+    mock_movie_class.from_file.assert_called_once_with(mock_file_path)
+
+    # Verify service attributes
+    assert service.movie == mock_movie
+    assert service.config.keep_original is False
+    assert service.config.keep_default is True  # Default value
+    assert service.config.keep_audio_langs == ["eng"]
+    assert service.config.keep_sub_langs == []  # Default value


### PR DESCRIPTION
This pull request introduces a new feature for cleaning media tracks based on configurable rules. It adds a `MediaTrackCleanService` to the codebase, implements its configuration and functionality, and includes tests to validate the feature. Below are the most important changes grouped by theme:

### New Feature: Media Track Cleaning
* Added `MediaTrackCleanService` to clean up media tracks based on configurable rules, such as keeping specific languages or default/original tracks. Includes methods for evaluating streams, generating ffmpeg commands, and replacing the original file with the processed file. (`workers/src/workers/services/media_track_clean.py`)
* Introduced `MediaTrackCleanConfig` and `MediaStream` classes to represent configuration and media stream metadata, respectively. These classes support parsing configuration dictionaries and ffprobe stream data. (`workers/src/workers/models/items.py`)

### Integration
* Registered `MediaTrackCleanService` in the service orchestrator and `__init__.py` for service discovery and usage. (`workers/src/workers/services/orchestrator.py`, `workers/src/workers/services/__init__.py`) [[1]](diffhunk://#diff-8ed163aeee4e857ebf47ca4439dafc9487c91c2660331ea9ec35005595fe9e54R21-R27) [[2]](diffhunk://#diff-bc0f6dea01b059143e6f13dd79556212a68dff23059ee77497e31db030e9766bR2-R8)
* Added an example configuration for `media_track_clean` to `jellyhook.example.json` for user reference. (`docs/examples/jellyhook.example.json`)

### Testing
* Created a new test suite for `MediaTrackCleanService`, including tests for keeping specific languages, multiple languages, and skipping processing when all streams are kept. (`workers/tests/component/services/test_media_track_clean.py`)
* Updated `conftest.py` with fixtures and mocks to support `MediaTrackCleanService` tests, including a multi-track test file and mocked file/command operations. (`workers/tests/component/conftest.py`) [[1]](diffhunk://#diff-5103688a2942d7cf20f24f0cf8e0a7ef59fb175a064ce6fd144c1d7ed98ebf9cR1) [[2]](diffhunk://#diff-5103688a2942d7cf20f24f0cf8e0a7ef59fb175a064ce6fd144c1d7ed98ebf9cL9-R10) [[3]](diffhunk://#diff-5103688a2942d7cf20f24f0cf8e0a7ef59fb175a064ce6fd144c1d7ed98ebf9cL42-R51) [[4]](diffhunk://#diff-5103688a2942d7cf20f24f0cf8e0a7ef59fb175a064ce6fd144c1d7ed98ebf9cR64-R68) [[5]](diffhunk://#diff-5103688a2942d7cf20f24f0cf8e0a7ef59fb175a064ce6fd144c1d7ed98ebf9cR79-R102) [[6]](diffhunk://#diff-5103688a2942d7cf20f24f0cf8e0a7ef59fb175a064ce6fd144c1d7ed98ebf9cR198-R220)